### PR TITLE
Add Gitlab CI file to update SNL Labs pages

### DIFF
--- a/instructions/develop-microservices-docker/.gitlab-ci.yml
+++ b/instructions/develop-microservices-docker/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-cdi-intro/.gitlab-ci.yml
+++ b/instructions/guide-cdi-intro/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-cloud-native/.gitlab-ci.yml
+++ b/instructions/guide-cloud-native/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-deploying-and-packinging-applications/.gitlab-ci.yml
+++ b/instructions/guide-deploying-and-packinging-applications/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-develop-java-microservice/.gitlab-ci.yml
+++ b/instructions/guide-develop-java-microservice/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-kube-health/.gitlab-ci.yml
+++ b/instructions/guide-kube-health/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-kubernetes-intro/.gitlab-ci.yml
+++ b/instructions/guide-kubernetes-intro/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-microprofile-config/.gitlab-ci.yml
+++ b/instructions/guide-microprofile-config/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-microprofile-fallback/.gitlab-ci.yml
+++ b/instructions/guide-microprofile-fallback/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-microprofile-jwt/.gitlab-ci.yml
+++ b/instructions/guide-microprofile-jwt/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-microprofile-reactive-messaging-acknowledgment/.gitlab-ci.yml
+++ b/instructions/guide-microprofile-reactive-messaging-acknowledgment/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-microprofile-reactive-messaging-rest-integration/.gitlab-ci.yml
+++ b/instructions/guide-microprofile-reactive-messaging-rest-integration/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-microprofile-rest-client-async/.gitlab-ci.yml
+++ b/instructions/guide-microprofile-rest-client-async/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-microprofile-rest-client/.gitlab-ci.yml
+++ b/instructions/guide-microprofile-rest-client/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-microservice2-k8/.gitlab-ci.yml
+++ b/instructions/guide-microservice2-k8/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-microshed-testing/.gitlab-ci.yml
+++ b/instructions/guide-microshed-testing/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-reactive-messaging-openshift/.gitlab-ci.yml
+++ b/instructions/guide-reactive-messaging-openshift/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-reactive-messaging/.gitlab-ci.yml
+++ b/instructions/guide-reactive-messaging/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-reactive-rest-client/.gitlab-ci.yml
+++ b/instructions/guide-reactive-rest-client/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-reactive-service-testing/.gitlab-ci.yml
+++ b/instructions/guide-reactive-service-testing/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-rest-intro/.gitlab-ci.yml
+++ b/instructions/guide-rest-intro/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-rest-openshift/.gitlab-ci.yml
+++ b/instructions/guide-rest-openshift/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"

--- a/instructions/guide-restful-webservice/.gitlab-ci.yml
+++ b/instructions/guide-restful-webservice/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+include:
+  - project: "ibm/skills-network/courses/shared-ci"
+    ref: master
+    file: "shared-ci.yml"


### PR DESCRIPTION
Fixes an issue with https://github.com/OpenLiberty/quick-labs/pull/56 where changes are not propagating from the Gitlab repo to the SNL page itself.

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>