### PR TITLE
Add mirror instructions to Gitlab repositories

### DIFF
--- a/instructions/develop-microservices-docker/README.MD
+++ b/instructions/develop-microservices-docker/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-cdi-intro/README.MD
+++ b/instructions/guide-cdi-intro/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-cloud-native/README.MD
+++ b/instructions/guide-cloud-native/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-deploying-and-packinging-applications/README.MD
+++ b/instructions/guide-deploying-and-packinging-applications/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-develop-java-microservice/README.MD
+++ b/instructions/guide-develop-java-microservice/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-kube-health/README.MD
+++ b/instructions/guide-kube-health/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-kubernetes-intro/README.MD
+++ b/instructions/guide-kubernetes-intro/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-microprofile-config/README.MD
+++ b/instructions/guide-microprofile-config/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-microprofile-fallback/README.MD
+++ b/instructions/guide-microprofile-fallback/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-microprofile-jwt/README.MD
+++ b/instructions/guide-microprofile-jwt/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-microprofile-reactive-messaging-acknowledgment/README.MD
+++ b/instructions/guide-microprofile-reactive-messaging-acknowledgment/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-microprofile-reactive-messaging-rest-integration/README.MD
+++ b/instructions/guide-microprofile-reactive-messaging-rest-integration/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-microprofile-rest-client-async/README.MD
+++ b/instructions/guide-microprofile-rest-client-async/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-microprofile-rest-client/README.MD
+++ b/instructions/guide-microprofile-rest-client/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-microservice2-k8/README.MD
+++ b/instructions/guide-microservice2-k8/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-microshed-testing/README.MD
+++ b/instructions/guide-microshed-testing/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-reactive-messaging-openshift/README.MD
+++ b/instructions/guide-reactive-messaging-openshift/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-reactive-messaging/README.MD
+++ b/instructions/guide-reactive-messaging/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-reactive-rest-client/README.MD
+++ b/instructions/guide-reactive-rest-client/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-reactive-service-testing/README.MD
+++ b/instructions/guide-reactive-service-testing/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-rest-intro/README.MD
+++ b/instructions/guide-rest-intro/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-rest-openshift/README.MD
+++ b/instructions/guide-rest-openshift/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file

--- a/instructions/guide-restful-webservice/README.MD
+++ b/instructions/guide-restful-webservice/README.MD
@@ -1,8 +1,5 @@
-# quick-labs
-A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
-
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
 1. Add the repository names to the `mirror.yml` file


### PR DESCRIPTION
Sets the README.MD for Gitlab repositories to the instructions for setting up a mirror.

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>