### PR TITLE
Message changes and set correct folder/name for guide

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,11 +1,12 @@
 # This is a basic workflow to help you get started with Actions
-name: automation
+name: Convert Guides
 on:
   repository_dispatch:
    types: [update]
 jobs:
   # This workflow contains a single job called "build"
   build:
+    name: Convert Guide
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -15,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
       env:
          SUPER_SECRET: ${{ secrets.SuperSecret }}
-    - name: run converter
+    - name: Run Converter
       run: |
         git init
         mkdir -p instructions/${{ github.event.client_payload.repository }}/
@@ -24,13 +25,14 @@ jobs:
         java GuideConverter ${{ github.event.client_payload.repository }}
         rm -f temp.adoc
         rm -f GuideConverter.class
+        mv ${{ github.event.client_payload.repository }}.md instructions/${{ github.event.client_payload.repository }}/instructions.md
         git add .
-        git config --global user.email "action@example.com"
-        git config --global user.name "action"
-        git commit -m "updated by github actions from ${{ github.event.client_payload.repository }}"
+        git config --global user.email "GuidesBot@OpenLiberty.io"
+        git config --global user.name "GuidesBot"
+        git commit -m "Updated by github actions from ${{ github.event.client_payload.repository }}"
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:
          title: "Change to ${{ github.event.client_payload.repository }}"
-         body: "Updated by github actions by the ${{ github.event.client_payload.repository }} repo"
+         body: "Updated by github actions, triggered by the ${{ github.event.client_payload.repository }} repo."
          branch: "${{ github.event.client_payload.repository }}/action"


### PR DESCRIPTION
Currently the PR's created by the GuidesBot only put the updated guide in the root directory, this PR aims to place the changed guide in the correct repository and give it the correct name for SNL (`instructions.md`).

Also included are some minor text changes for clarity.

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>