### PR TITLE
Update README instructions to create a Quicklab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # quick-labs
 A temp repo to store instructions and other artifacts in regards to our Quick Labs and Workshops
 
-# Mirror to Gitlab
-All of the folders under `instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
+# Mirror Instructions
+All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -25,7 +33,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/develop-microservices-docker/README.MD
+++ b/instructions/develop-microservices-docker/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-cdi-intro/README.MD
+++ b/instructions/guide-cdi-intro/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-cloud-native/README.MD
+++ b/instructions/guide-cloud-native/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-deploying-and-packinging-applications/README.MD
+++ b/instructions/guide-deploying-and-packinging-applications/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-kube-health/README.MD
+++ b/instructions/guide-kube-health/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-kubernetes-intro/README.MD
+++ b/instructions/guide-kubernetes-intro/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-microprofile-config/README.MD
+++ b/instructions/guide-microprofile-config/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-microprofile-fallback/README.MD
+++ b/instructions/guide-microprofile-fallback/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-microprofile-jwt/README.MD
+++ b/instructions/guide-microprofile-jwt/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-microprofile-opentracing/README.MD
+++ b/instructions/guide-microprofile-opentracing/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-microprofile-reactive-messaging-acknowledgment/README.MD
+++ b/instructions/guide-microprofile-reactive-messaging-acknowledgment/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-microprofile-reactive-messaging-rest-integration/README.MD
+++ b/instructions/guide-microprofile-reactive-messaging-rest-integration/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-microprofile-rest-client-async/README.MD
+++ b/instructions/guide-microprofile-rest-client-async/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-microprofile-rest-client/README.MD
+++ b/instructions/guide-microprofile-rest-client/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-microshed-testing/README.MD
+++ b/instructions/guide-microshed-testing/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-reactive-messaging-openshift/README.MD
+++ b/instructions/guide-reactive-messaging-openshift/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-reactive-messaging/README.MD
+++ b/instructions/guide-reactive-messaging/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-reactive-rest-client/README.MD
+++ b/instructions/guide-reactive-rest-client/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-reactive-service-testing/README.MD
+++ b/instructions/guide-reactive-service-testing/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-rest-openshift/README.MD
+++ b/instructions/guide-rest-openshift/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 

--- a/instructions/guide-restful-webservice/README.MD
+++ b/instructions/guide-restful-webservice/README.MD
@@ -2,9 +2,17 @@
 All of the folders under `https://github.com/OpenLiberty/quick-labs/tree/master/instructions/` have a matching Gitlab repository used for SkillsNetwork labs.
 When creating a new quick-labs guide some steps must be taken to ensure that future changes will be mirrored.
 
-1. Add the repository names to the `mirror.yml` file
+1. Create the Quicklab 
 
-In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository names.
+Create the neccessary Quicklab repository on Gitlab via the SkillsNetwork Author page: https://www.skills.network/become-an-author/
+
+2. Add the OpenLiberty Guides group
+
+Once your Quicklab repository has been created navigate to it on Gitlab and select the "Members" tab. From here select the "Invite Group" tab and invite the "[OpenLiberty Guides](https://gitlab.com/openliberty-guides)" group as a `maintainer`. If you are not yet a member of the OpenLiberty Guides group then tag @austin0, @jamiecoleman92, or @jakub-pomykala on Github.
+
+3. Add the repository names to the `mirror.yml` file
+
+In the following section of mirror.yml, under the `repo:` tag, you must add both the Github folder and Gitlab repository (URL) names.
 ```
 jobs:
   deploy:
@@ -22,7 +30,7 @@ jobs:
 ```
 
 
-2. Apply Gitlab deploy key
+4. Apply Gitlab deploy key
 
 Once the Gitlab repository has been created the owner/maintainer must assign the correct deploy key.
 This can be done by going to `https://gitlab.com/ibm/skills-network/quicklabs/<repo-name>/settings/repository`, scrolling down to the `Deploy Keys` section and enabling the `DEPLOY_KEY_QUICK_LABS` key. 


### PR DESCRIPTION
Improves the README instructions on how to create a Quicklab and inviting other OpenLiberty members to the repositories.

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>