### PR TITLE
Correct capitalization on Gitlab repository names

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -25,10 +25,10 @@ jobs:
           - {"github":"guide-microprofile-fallback","gitlab":"fault-tolerant-microservices-with-ol-and-microprofile"}
           - {"github":"guide-microprofile-jwt","gitlab":"securing-microservices-with-json-web-token"}
           - {"github":"guide-microprofile-opentracing","gitlab":"enabling-distributed-tracing-in-microservices-with-zipkin"}
-          - {"github":"guide-microprofile-reactive-messaging-acknowledgment","gitlab":"Acknowledging-messages-using-MicroProfile-Reactive-Messaging"}
-          - {"github":"guide-microprofile-reactive-messaging-rest-integration","gitlab":"Integrating-RESTful-services-with-a-reactive-system"}
+          - {"github":"guide-microprofile-reactive-messaging-acknowledgment","gitlab":"acknowledging-messages-using-microprofile-reactive-messaging"}
+          - {"github":"guide-microprofile-reactive-messaging-rest-integration","gitlab":"integrating-restful-services-with-a-reactive-system"}
           - {"github":"guide-microprofile-rest-client","gitlab":"consuming-restful-services-with-template-interfaces-with-ol"}
-          - {"github":"guide-microprofile-rest-client-async","gitlab":"Consuming-RESTful-services-asynchronously-with-template-interfaces"}
+          - {"github":"guide-microprofile-rest-client-async","gitlab":"consuming-restful-services-asynchronously-with-template-interfaces"}
           - {"github":"guide-microshed-testing","gitlab":"learn-how-to-use-microshed-testing"}
           - {"github":"guide-reactive-messaging","gitlab":"creating-reactive-microservices-using-microprofile-reactive-messaging-with-docker"}
           - {"github":"guide-reactive-messaging-openshift","gitlab":"creating-reactive-microservices-using-microprofile-reactive-messaging"}

--- a/.github/workflows/stagingMirror.yml
+++ b/.github/workflows/stagingMirror.yml
@@ -24,10 +24,10 @@ jobs:
           - {"github":"guide-microprofile-config","gitlab":"configuring-java-microservices"}
           - {"github":"guide-microprofile-fallback","gitlab":"fault-tolerant-microservices-with-ol-and-microprofile"}
           - {"github":"guide-microprofile-jwt","gitlab":"securing-microservices-with-json-web-token"}
-          - {"github":"guide-microprofile-reactive-messaging-acknowledgment","gitlab":"Acknowledging-messages-using-MicroProfile-Reactive-Messaging"}
-          - {"github":"guide-microprofile-reactive-messaging-rest-integration","gitlab":"Integrating-RESTful-services-with-a-reactive-system"}
+          - {"github":"guide-microprofile-reactive-messaging-acknowledgment","gitlab":"acknowledging-messages-using-microprofile-reactive-messaging"}
+          - {"github":"guide-microprofile-reactive-messaging-rest-integration","gitlab":"integrating-restful-services-with-a-reactive-system"}
           - {"github":"guide-microprofile-rest-client","gitlab":"consuming-restful-services-with-template-interfaces-with-ol"}
-          - {"github":"guide-microprofile-rest-client-async","gitlab":"Consuming-RESTful-services-asynchronously-with-template-interfaces"}
+          - {"github":"guide-microprofile-rest-client-async","gitlab":"consuming-restful-services-asynchronously-with-template-interfaces"}
           - {"github":"guide-microshed-testing","gitlab":"learn-how-to-use-microshed-testing"}
           - {"github":"guide-reactive-messaging","gitlab":"creating-reactive-microservices-using-microprofile-reactive-messaging-with-docker"}
           - {"github":"guide-reactive-messaging-openshift","gitlab":"creating-reactive-microservices-using-microprofile-reactive-messaging"}


### PR DESCRIPTION
Fixes an issue where the GitHub action would return a link to the staging quicklab that did not work. This was due to errant capital letters in the repository name matrix.

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>