### PR TITLE
Force java 11 on github actions

### DIFF
--- a/.github/workflows/GuideConverterAction.yml
+++ b/.github/workflows/GuideConverterAction.yml
@@ -25,21 +25,27 @@ jobs:
   convertMaster:
     name: Make PR to Master
     runs-on: ubuntu-latest
-    if: contains(github.event.inputs.branch, 'sn-automation-testing-master')
+    if: contains(github.event.inputs.branch, 'master')
   
     steps:
 
       # Any prerequisite steps
       - uses: actions/checkout@master
 
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11' # The JDK version to make available on the path.
+          java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
+          architecture: x64 # (x64 or x86) - defaults to x64
       
       - name: Run Converter
         run: |
+          branchName=${{ github.event.inputs.branch }}
           git init
           mkdir -p instructions/${{ github.event.inputs.guide_name }}/
           rm -f instructions/${{ github.event.inputs.guide_name }}/README.md
           javac GuideConverterV2.java
-          java GuideConverterV2 ${{ github.event.inputs.guide_name }} master
+          java GuideConverterV2 ${{ github.event.inputs.guide_name }} ${branchName:11}
           rm -f importFunctions.class
           rm -f functions.class
           rm -f GuideConverterV2.class
@@ -60,20 +66,27 @@ jobs:
   convertStaging:
     name: Make PR to Staging
     runs-on: ubuntu-latest
-    if: contains(github.event.inputs.branch, 'sn-automation-testing-qa')
+    if: contains(github.event.inputs.branch, 'qa')
   
     steps:
 
       # Any prerequisite steps
       - uses: actions/checkout@master
 
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11' # The JDK version to make available on the path.
+          java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
+          architecture: x64 # (x64 or x86) - defaults to x64
+
       - name: Run Converter
         run: |
+          branchName=${{ github.event.inputs.branch }}
           git init
           mkdir -p instructions/${{ github.event.inputs.guide_name }}/
           rm -f instructions/${{ github.event.inputs.guide_name }}/README.md
           javac GuideConverterV2.java
-          java GuideConverterV2 ${{ github.event.inputs.guide_name }} qa
+          java GuideConverterV2 ${{ github.event.inputs.guide_name }} ${branchName:11}
           rm -f importFunctions.class
           rm -f functions.class
           rm -f GuideConverterV2.class


### PR DESCRIPTION
Fixes a compilation error where Java 11 code would not run on the Github actions hosted runners.

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>