### PR TITLE
Update examples to only run when changes are made to guide materials

### DIFF
--- a/Examples/draftTriggerQuickLabs.yml
+++ b/Examples/draftTriggerQuickLabs.yml
@@ -5,9 +5,14 @@ name: Trigger quick-labs
 on:
   push:
     branches:
-    - master
-    - main
-    - dev
+      - 'master'
+      - 'main'
+      - 'dev'
+    paths:
+      - 'README.adoc'
+      - 'start/**'
+      - 'finish/**'
+      - 'assets/**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Updates the example actions files to avoid pushing empty commits to the `quick-labs' repository, by only running when changes are made to the guide and associated material.

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>