### PR TITLE
Remove draft guides when a release version is published

### DIFF
--- a/.github/workflows/GuideConverterAction.yml
+++ b/.github/workflows/GuideConverterAction.yml
@@ -5,7 +5,7 @@ on:
       branch:
         description: 'Branch pushed to'     
         required: true
-        default: 'qa'
+        default: 'refs/heads/master'
       guide_name:
         description: 'Guide changed'
         required: true
@@ -59,6 +59,7 @@ jobs:
           cd ..
           mv GuideConverter/${{ github.event.inputs.guide_name }}.md instructions/${{ github.event.inputs.guide_name }}/instructions.md
           rm -r GuideConverter
+          bash .github/workflows/draftRemoval.sh ${{ github.event.inputs.guide_name }}
           git add .
           git config --global user.email "GuidesBot@OpenLiberty.io"
           git config --global user.name "GuidesBot"
@@ -110,6 +111,7 @@ jobs:
           cd ..
           mv GuideConverter/${{ github.event.inputs.guide_name }}.md instructions/${{ github.event.inputs.guide_name }}/instructions.md
           rm -r GuideConverter
+          bash /.github/workflows/draftRemoval.sh ${{ github.event.inputs.guide_name }}
           git add .
           git config --global user.email "GuidesBot@OpenLiberty.io"
           git config --global user.name "GuidesBot"

--- a/.github/workflows/draftRemoval.sh
+++ b/.github/workflows/draftRemoval.sh
@@ -1,0 +1,6 @@
+if [[ -d "instructions/draft-$1" ]]; then
+    rm -rf instructions/draft-$1
+    echo "Removed draft-$1"
+else
+    echo "No draft guide found (draft-$1)"
+fi


### PR DESCRIPTION
Adds a small script to remove a `draft-guide-x` folder when it is replaced with a published `guide-x` folder.

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>