### PR TITLE
Updating actions to clone Guides and run GuideConverter locally

### DIFF
--- a/.github/workflows/DraftGuideAction.yml
+++ b/.github/workflows/DraftGuideAction.yml
@@ -28,14 +28,33 @@ jobs:
   
     steps:
 
-      # Any prerequisite steps
-      - uses: actions/checkout@master
+           # Any prerequisite steps
+       - uses: actions/checkout@master
         
       - name: Checkout Guide Converter repo
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/cloud-hosted-guide-converter
           path: GuideConverter
+
+
+          # Any prerequisite steps
+      - uses: actions/checkout@master
+        
+      - name: Checkout guide repo
+        uses: actions/checkout@v2
+        with:
+          repository: OpenLiberty/${{ github.event.inputs.guide_name }}
+          path: Guide-repo
+
+          # Any prerequisite steps
+      - uses: actions/checkout@master
+        
+      - name: Checkout guides-common repo
+        uses: actions/checkout@v2
+        with:
+          repository: OpenLiberty/guides-common
+          path: Guides-common
 
       - uses: actions/setup-java@v1
         with:
@@ -48,21 +67,24 @@ jobs:
           branchName=${{ github.event.inputs.branch }}
           git init
           mkdir -p instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/
-          rm -f instructions/cloud-hosted-$${{ github.event.inputs.guide_name }}/README.md
+          rm -f instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/README.md
           cd GuideConverter
-          javac *.java
+          javac CloudHostedGuideConverter.java
           java CloudHostedGuideConverter ${{ github.event.inputs.guide_name }} ${branchName:11}
           rm -f importFunctions.class
           rm -f functions.class
           rm -f CloudHostedGuideConverter.class
           cd ..
-          mv GuideConverter/${{ github.event.inputs.guide_name }}.md instructions/cloud-hosted-$${{ github.event.inputs.guide_name }}/instructions.md
+          mv GuideConverter/${{ github.event.inputs.guide_name }}.md instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/instructions.md
           rm -r GuideConverter
+          rm -r Guide-repo
+          rm -r Guides-common
+          bash .github/workflows/draftRemoval.sh cloud-hosted-${{ github.event.inputs.guide_name }}
           git add .
           git config --global user.email "GuidesBot@OpenLiberty.io"
           git config --global user.name "GuidesBot"
           git commit -m "Updated by github actions from ${{ github.event.inputs.guide_name }}"
-          git checkout --ours instructions/cloud-hosted-$${{ github.event.inputs.guide_name }}/instructions.md
+          git checkout --ours instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/instructions.md
     
       - uses: peter-evans/create-pull-request@v3
         with:

--- a/.github/workflows/DraftGuideAction.yml
+++ b/.github/workflows/DraftGuideAction.yml
@@ -29,32 +29,25 @@ jobs:
     steps:
 
            # Any prerequisite steps
-       - uses: actions/checkout@master
+      - uses: actions/checkout@master
         
       - name: Checkout Guide Converter repo
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/cloud-hosted-guide-converter
           path: GuideConverter
-
-
-          # Any prerequisite steps
-      - uses: actions/checkout@master
         
       - name: Checkout guide repo
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/${{ github.event.inputs.guide_name }}
-          path: Guide-repo
-
-          # Any prerequisite steps
-      - uses: actions/checkout@master
+          path: GuideConverter/Guide-repo
         
       - name: Checkout guides-common repo
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/guides-common
-          path: Guides-common
+          path: GuideConverter/Guides-common
 
       - uses: actions/setup-java@v1
         with:
@@ -77,8 +70,6 @@ jobs:
           cd ..
           mv GuideConverter/${{ github.event.inputs.guide_name }}.md instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/instructions.md
           rm -r GuideConverter
-          rm -r Guide-repo
-          rm -r Guides-common
           bash .github/workflows/draftRemoval.sh cloud-hosted-${{ github.event.inputs.guide_name }}
           git add .
           git config --global user.email "GuidesBot@OpenLiberty.io"

--- a/.github/workflows/DraftGuideAction.yml
+++ b/.github/workflows/DraftGuideAction.yml
@@ -28,7 +28,7 @@ jobs:
   
     steps:
 
-           # Any prerequisite steps
+      # Any prerequisite steps
       - uses: actions/checkout@master
         
       - name: Checkout Guide Converter repo

--- a/.github/workflows/DraftGuideAction.yml
+++ b/.github/workflows/DraftGuideAction.yml
@@ -69,7 +69,7 @@ jobs:
           rm -f CloudHostedGuideConverter.class
           cd ..
           mv GuideConverter/${{ github.event.inputs.guide_name }}.md instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/instructions.md
-          rm -r GuideConverter
+          rm -rf GuideConverter
           bash .github/workflows/draftRemoval.sh cloud-hosted-${{ github.event.inputs.guide_name }}
           git add .
           git config --global user.email "GuidesBot@OpenLiberty.io"

--- a/.github/workflows/GuideConverterAction.yml
+++ b/.github/workflows/GuideConverterAction.yml
@@ -37,25 +37,18 @@ jobs:
         with:
           repository: OpenLiberty/cloud-hosted-guide-converter
           path: GuideConverter
-
-
-          # Any prerequisite steps
-      - uses: actions/checkout@master
         
       - name: Checkout guide repo
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/${{ github.event.inputs.guide_name }}
-          path: Guide-repo
-
-          # Any prerequisite steps
-      - uses: actions/checkout@master
+          path: GuideConverter/Guide-repo
         
       - name: Checkout guides-common repo
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/guides-common
-          path: Guides-common
+          path: GuideConverter/Guides-common
 
       - uses: actions/setup-java@v1
         with:
@@ -77,9 +70,7 @@ jobs:
           rm -f CloudHostedGuideConverter.class
           cd ..
           mv GuideConverter/${{ github.event.inputs.guide_name }}.md instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/instructions.md
-          rm -r GuideConverter
-          rm -r Guide-repo
-          rm -r Guides-common
+          rm -rf GuideConverter
           bash .github/workflows/draftRemoval.sh cloud-hosted-${{ github.event.inputs.guide_name }}
           git add .
           git config --global user.email "GuidesBot@OpenLiberty.io"
@@ -103,32 +94,25 @@ jobs:
     steps:
 
       # Any prerequisite steps
-       - uses: actions/checkout@master
+      - uses: actions/checkout@master
         
       - name: Checkout Guide Converter repo
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/cloud-hosted-guide-converter
           path: GuideConverter
-
-
-          # Any prerequisite steps
-      - uses: actions/checkout@master
         
       - name: Checkout guide repo
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/${{ github.event.inputs.guide_name }}
-          path: Guide-repo
-
-          # Any prerequisite steps
-      - uses: actions/checkout@master
+          path: GuideConverter/Guide-repo
         
       - name: Checkout guides-common repo
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/guides-common
-          path: Guides-common
+          path: GuideConverter/Guides-common
 
       - uses: actions/setup-java@v1
         with:
@@ -150,9 +134,7 @@ jobs:
           rm -f CloudHostedGuideConverter.class
           cd ..
           mv GuideConverter/${{ github.event.inputs.guide_name }}.md instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/instructions.md
-          rm -r GuideConverter
-          rm -r Guide-repo
-          rm -r Guides-common
+          rm -rf GuideConverter
           bash .github/workflows/draftRemoval.sh cloud-hosted-${{ github.event.inputs.guide_name }}
           git add .
           git config --global user.email "GuidesBot@OpenLiberty.io"

--- a/.github/workflows/GuideConverterAction.yml
+++ b/.github/workflows/GuideConverterAction.yml
@@ -38,6 +38,25 @@ jobs:
           repository: OpenLiberty/cloud-hosted-guide-converter
           path: GuideConverter
 
+
+          # Any prerequisite steps
+      - uses: actions/checkout@master
+        
+      - name: Checkout guide repo
+        uses: actions/checkout@v2
+        with:
+          repository: OpenLiberty/${{ github.event.inputs.guide_name }}
+          path: Guide-repo
+
+          # Any prerequisite steps
+      - uses: actions/checkout@master
+        
+      - name: Checkout guides-common repo
+        uses: actions/checkout@v2
+        with:
+          repository: OpenLiberty/guides-common
+          path: Guides-common
+
       - uses: actions/setup-java@v1
         with:
           java-version: '11' # The JDK version to make available on the path.
@@ -59,6 +78,8 @@ jobs:
           cd ..
           mv GuideConverter/${{ github.event.inputs.guide_name }}.md instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/instructions.md
           rm -r GuideConverter
+          rm -r Guide-repo
+          rm -r Guides-common
           bash .github/workflows/draftRemoval.sh cloud-hosted-${{ github.event.inputs.guide_name }}
           git add .
           git config --global user.email "GuidesBot@OpenLiberty.io"
@@ -82,13 +103,32 @@ jobs:
     steps:
 
       # Any prerequisite steps
-      - uses: actions/checkout@master
-      
+       - uses: actions/checkout@master
+        
       - name: Checkout Guide Converter repo
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/cloud-hosted-guide-converter
           path: GuideConverter
+
+
+          # Any prerequisite steps
+      - uses: actions/checkout@master
+        
+      - name: Checkout guide repo
+        uses: actions/checkout@v2
+        with:
+          repository: OpenLiberty/${{ github.event.inputs.guide_name }}
+          path: Guide-repo
+
+          # Any prerequisite steps
+      - uses: actions/checkout@master
+        
+      - name: Checkout guides-common repo
+        uses: actions/checkout@v2
+        with:
+          repository: OpenLiberty/guides-common
+          path: Guides-common
 
       - uses: actions/setup-java@v1
         with:
@@ -111,6 +151,8 @@ jobs:
           cd ..
           mv GuideConverter/${{ github.event.inputs.guide_name }}.md instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/instructions.md
           rm -r GuideConverter
+          rm -r Guide-repo
+          rm -r Guides-common
           bash .github/workflows/draftRemoval.sh cloud-hosted-${{ github.event.inputs.guide_name }}
           git add .
           git config --global user.email "GuidesBot@OpenLiberty.io"

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -16,6 +16,7 @@ jobs:
               # i.e. {"github":"new-lab-github-url","gitlab":"new-lab-gitlab-url"}
         repo: 
           - {"github":"cloud-hosted-guide-cdi-intro","gitlab":"cloud-hosted-guide-cdi-intro"}
+          - {"github":"guide-containerize","gitlab":"cloud-hosted-guide-containerize"}
           - {"github":"cloud-hosted-guide-docker","gitlab":"cloud-hosted-guide-docker"}
           - {"github":"cloud-hosted-guide-getting-started","gitlab":"cloud-hosted-guide-getting-started"}
           - {"github":"cloud-hosted-guide-kubernetes-intro","gitlab":"cloud-hosted-guide-kubernetes-intro"}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -16,7 +16,7 @@ jobs:
               # i.e. {"github":"new-lab-github-url","gitlab":"new-lab-gitlab-url"}
         repo: 
           - {"github":"cloud-hosted-guide-cdi-intro","gitlab":"cloud-hosted-guide-cdi-intro"}
-          - {"github":"guide-containerize","gitlab":"cloud-hosted-guide-containerize"}
+          - {"github":"cloud-hosted-guide-containerize","gitlab":"cloud-hosted-guide-containerize"}
           - {"github":"cloud-hosted-guide-docker","gitlab":"cloud-hosted-guide-docker"}
           - {"github":"cloud-hosted-guide-getting-started","gitlab":"cloud-hosted-guide-getting-started"}
           - {"github":"cloud-hosted-guide-kubernetes-intro","gitlab":"cloud-hosted-guide-kubernetes-intro"}

--- a/.github/workflows/stagingMirror.yml
+++ b/.github/workflows/stagingMirror.yml
@@ -16,6 +16,7 @@ jobs:
               # i.e. {"github":"new-lab-github-url","gitlab":"new-lab-gitlab-url"}
         repo: 
           - {"github":"cloud-hosted-guide-cdi-intro","gitlab":"cloud-hosted-guide-cdi-intro"}
+          - {"github":"guide-containerize","gitlab":"cloud-hosted-guide-containerize"}
           - {"github":"cloud-hosted-guide-docker","gitlab":"cloud-hosted-guide-docker"}
           - {"github":"cloud-hosted-guide-getting-started","gitlab":"cloud-hosted-guide-getting-started"}
           - {"github":"cloud-hosted-guide-kubernetes-intro","gitlab":"cloud-hosted-guide-kubernetes-intro"}

--- a/.github/workflows/stagingMirror.yml
+++ b/.github/workflows/stagingMirror.yml
@@ -16,7 +16,7 @@ jobs:
               # i.e. {"github":"new-lab-github-url","gitlab":"new-lab-gitlab-url"}
         repo: 
           - {"github":"cloud-hosted-guide-cdi-intro","gitlab":"cloud-hosted-guide-cdi-intro"}
-          - {"github":"guide-containerize","gitlab":"cloud-hosted-guide-containerize"}
+          - {"github":"cloud-hosted-guide-containerize","gitlab":"cloud-hosted-guide-containerize"}
           - {"github":"cloud-hosted-guide-docker","gitlab":"cloud-hosted-guide-docker"}
           - {"github":"cloud-hosted-guide-getting-started","gitlab":"cloud-hosted-guide-getting-started"}
           - {"github":"cloud-hosted-guide-kubernetes-intro","gitlab":"cloud-hosted-guide-kubernetes-intro"}


### PR DESCRIPTION
The GuideConverter now runs on local guides, this means that the action has been changed to clone the repo of the guide (& guides-common) and then delete the these repos after. This is so that there is no downtime like there was when the GuideConverter was running using the GitHub API. In this PR there is also a change included to the `mirror.yml` files where I previously didn't add `cloud-hosted-` at the beginning of one of the files. 