### PR TITLE
Add support for various branch name on guide repositories

### DIFF
--- a/.github/workflows/DraftGuideAction.yml
+++ b/.github/workflows/DraftGuideAction.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/${{ github.event.inputs.guide_name }}
-          path: GuideConverter/Guide-repo
+          path: GuideConverter/${{ github.event.inputs.guide_name }}
         
       - name: Checkout guides-common repo
         uses: actions/checkout@v2
@@ -64,8 +64,8 @@ jobs:
           mkdir -p instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/
           rm -f instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/README.md
           cd GuideConverter
-          javac CloudHostedGuideConverter.java
-          java CloudHostedGuideConverter ${{ github.event.inputs.guide_name }} qa
+          mvn package -Dmaven.test.skip=true 
+          mvn exec:java -Dexec.args="${{ github.event.inputs.guide_name }} qa"
           rm -f importFunctions.class
           rm -f functions.class
           rm -f CloudHostedGuideConverter.class

--- a/.github/workflows/DraftGuideAction.yml
+++ b/.github/workflows/DraftGuideAction.yml
@@ -65,7 +65,7 @@ jobs:
           rm -f instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/README.md
           cd GuideConverter
           javac CloudHostedGuideConverter.java
-          java CloudHostedGuideConverter ${{ github.event.inputs.guide_name }} ${branchName:11}
+          java CloudHostedGuideConverter ${{ github.event.inputs.guide_name }} qa
           rm -f importFunctions.class
           rm -f functions.class
           rm -f CloudHostedGuideConverter.class

--- a/.github/workflows/GuideConverterAction.yml
+++ b/.github/workflows/GuideConverterAction.yml
@@ -25,7 +25,7 @@ jobs:
   convertMaster:
     name: Make PR to Master
     runs-on: ubuntu-latest
-    if: contains(github.event.inputs.branch, 'master')
+    if: contains(github.event.inputs.branch, 'master') || contains(github.event.inputs.branch, 'main') || contains(github.event.inputs.branch, 'prod')
   
     steps:
 
@@ -64,7 +64,7 @@ jobs:
           rm -f instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/README.md
           cd GuideConverter
           javac CloudHostedGuideConverter.java
-          java CloudHostedGuideConverter ${{ github.event.inputs.guide_name }} ${branchName:11}
+          java CloudHostedGuideConverter ${{ github.event.inputs.guide_name }} master
           rm -f importFunctions.class
           rm -f functions.class
           rm -f CloudHostedGuideConverter.class
@@ -89,7 +89,7 @@ jobs:
   convertStaging:
     name: Make PR to Staging
     runs-on: ubuntu-latest
-    if: contains(github.event.inputs.branch, 'qa')
+    if: contains(github.event.inputs.branch, 'qa') || contains(github.event.inputs.branch, 'staging')
   
     steps:
 
@@ -131,7 +131,7 @@ jobs:
           rm -f instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/README.md
           cd GuideConverter
           javac CloudHostedGuideConverter.java
-          java CloudHostedGuideConverter ${{ github.event.inputs.guide_name }} ${branchName:11}
+          java CloudHostedGuideConverter ${{ github.event.inputs.guide_name }} qa
           rm -f importFunctions.class
           rm -f functions.class
           rm -f CloudHostedGuideConverter.class

--- a/.github/workflows/GuideConverterAction.yml
+++ b/.github/workflows/GuideConverterAction.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: OpenLiberty/${{ github.event.inputs.guide_name }}
-          path: GuideConverter/Guide-repo
+          path: GuideConverter/${{ github.event.inputs.guide_name }}
         
       - name: Checkout guides-common repo
         uses: actions/checkout@v2
@@ -63,8 +63,8 @@ jobs:
           mkdir -p instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/
           rm -f instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/README.md
           cd GuideConverter
-          javac CloudHostedGuideConverter.java
-          java CloudHostedGuideConverter ${{ github.event.inputs.guide_name }} master
+          mvn package -Dmaven.test.skip=true 
+          mvn exec:java -Dexec.args="${{ github.event.inputs.guide_name }} master"
           rm -f importFunctions.class
           rm -f functions.class
           rm -f CloudHostedGuideConverter.class
@@ -109,7 +109,7 @@ jobs:
         with:
           ref: qa
           repository: OpenLiberty/${{ github.event.inputs.guide_name }}
-          path: GuideConverter/Guide-repo
+          path: GuideConverter/${{ github.event.inputs.guide_name }}
         
       - name: Checkout guides-common repo
         uses: actions/checkout@v2
@@ -130,8 +130,8 @@ jobs:
           mkdir -p instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/
           rm -f instructions/cloud-hosted-${{ github.event.inputs.guide_name }}/README.md
           cd GuideConverter
-          javac CloudHostedGuideConverter.java
-          java CloudHostedGuideConverter ${{ github.event.inputs.guide_name }} qa
+          mvn package -Dmaven.test.skip=true 
+          mvn exec:java -Dexec.args="${{ github.event.inputs.guide_name }} qa"
           rm -f importFunctions.class
           rm -f functions.class
           rm -f CloudHostedGuideConverter.class


### PR DESCRIPTION
Currently the guide converter will only work with guides that have branches called `master` and `qa`, this PR adds support for the following branch names:

Live branches:
- `main`
- `prod`

Staging branches:
- `staging`

This PR also updates the actions to function correctly with the updated guide converter.