### PR TITLE
Remove tags on Dewan's OC guide

### DIFF
--- a/instructions/cloud-hosted-guide-rest-openshift/instructions.md
+++ b/instructions/cloud-hosted-guide-rest-openshift/instructions.md
@@ -123,9 +123,7 @@ Next update the **server** config file.
   **File** > **Open** > guide-docker/finish/src/main/liberty/config/server.xml
 
 ```
-  <!-- tag::webApplication[] -->
   <webApplication location="rest.war" contextRoot="/LibertyProject"/>
-  <!-- end::webApplication[] -->
 ```
 {: codeblock}
 


### PR DESCRIPTION
Removes an unnecessary set of tags in guide-rest-openshift. 

Staging link: https://labs.cognitiveclass.ai/tools/theiadocker/lab/tree?md_instructions_url=https://cf-course-data-staging.s3.us-east.cloud-object-storage.appdomain.cloud/cloud-hosted-guide-rest-openshift/instructions.md

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>