### PR TITLE
Fix GuideConverterAction.yml

### DIFF
--- a/.github/workflows/GuideConverterAction.yml
+++ b/.github/workflows/GuideConverterAction.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Checkout guide repo
         uses: actions/checkout@v2
         with:
-          ref: qa
+          ref: ${{ github.event.inputs.branch }}
           repository: OpenLiberty/${{ github.event.inputs.guide_name }}
           path: GuideConverter/${{ github.event.inputs.guide_name }}
         


### PR DESCRIPTION
use `${{ github.event.inputs.branch }}` instead of `qa` when checkout guide repo for convert staging